### PR TITLE
Fix typos in connection failure log message

### DIFF
--- a/ATC_MiThermometer/TelinkMiFlasher.html
+++ b/ATC_MiThermometer/TelinkMiFlasher.html
@@ -80,7 +80,7 @@ function handleError(error) {
 		addLog("Reconnect " + connectTrys + " from " + 5);
 		doConnect();
 	} else {
-		addLog("Something went wrong, to many reconnect's");
+		addLog("Something went wrong, too many reconnects");
 		connectTrys = 0;
 	}
 }

--- a/ATC_MiThermometer/TelinkOTA.html
+++ b/ATC_MiThermometer/TelinkOTA.html
@@ -32,7 +32,7 @@ function handleError(error) {
         addLog("Reconnect " + connectTrys + " from " + 5);
         doConnect();
     } else {
-        addLog("Something went wrong, to many reconnect's");
+        addLog("Something went wrong, too many reconnects");
         connectTrys = 0;
     }
 }

--- a/CGPR1/TLSR825xOTA_Hacker.html
+++ b/CGPR1/TLSR825xOTA_Hacker.html
@@ -43,7 +43,7 @@ function handleError(error) {
         addLog("Reconnect " + connectTrys + " from " + 5);
         doConnect();
     } else {
-        addLog("Something went wrong, to many reconnect's");
+        addLog("Something went wrong, too many reconnects");
         connectTrys = 0;
     }
 }

--- a/UBIA/TelinkOTA.html
+++ b/UBIA/TelinkOTA.html
@@ -32,7 +32,7 @@ function handleError(error) {
         addLog("Reconnect " + connectTrys + " from " + 5);
         doConnect();
     } else {
-        addLog("Something went wrong, to many reconnect's");
+        addLog("Something went wrong, too many reconnects");
         connectTrys = 0;
     }
 }


### PR DESCRIPTION
When connection to BLE sensor fails after 5 connection tries, the log message is displayed. It has some typos, which this PR fixes.