### PR TITLE
fix: devices filter

### DIFF
--- a/ATC_MiThermometer/GraphMemo.html
+++ b/ATC_MiThermometer/GraphMemo.html
@@ -369,7 +369,7 @@ function connect() {
 // Запрос выбора Bluetooth устройства
 function requestBluetoothDevice() {
 	var deviceOptions = {optionalServices: [0xfe95, 0x181a, 0x1f10]};
-	deviceOptions.filters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz_#@!*';,.<>{}[]"
+	deviceOptions.filters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz_#@!*0123456789';,.<>{}[]"
 	.split("").map((x) => ({namePrefix:x}));
 	// deviceOptions.filters.services = [0xfe95, 0x181a, 0x1f10];
 	log('Requesting bluetooth device...');


### PR DESCRIPTION
Hi @pvvx Victor,

I'm having trouble using the Graph Memo function. I couldn't connect because my device wasn't in the device list. 
If after renaming the device there is a number in the name, for example "1st tunnel", then it was impossible to connect to it.
I found a one-line solution to this problem.

https://github.com/pvvx/pvvx.github.io/blob/master/ATC_MiThermometer/GraphMemo.html#L372