### PR TITLE
Add missing hwver_id checks for MJWSD05MMC (en)

### DIFF
--- a/ATC_MiThermometer/TelinkMiFlasher.html
+++ b/ATC_MiThermometer/TelinkMiFlasher.html
@@ -2856,7 +2856,7 @@ function CustomConfig() {
 	if((hwver_id == 17) || (hwver_id == 27))
 		is += '<hr><label id="lblSensor2"><b>Sensor2 Settings:</b></label><br>Temperature Slope factor: <input size="8" type="text" id="inpTemp2K" maxlength="8" title="Tk: Slope factor (linear function) for temperature calculation (T=RegT*Tk/65536+Tz)"> , Zero offset: <input size="8" type="text" id="inpTemp2Z" maxlength="8" title="Tz: Zero offset with correction value for temperature calculation (T=RegT*Tk/65536+Tz)"><br><button type="button"id="btnGetSens2" onclick="getSens2Cfg()">Get Sensor2 Settings</button> <button type="button"id="btnSetSens2" onclick="setSens2Cfg()">Send Sensor2 Settings</button> <button type="button"id="btnRstSens2" onclick="resetSens2Cfg()" title="Restore default sensor2 settings">Set Default</button><br>';
 
-	if(cfg.ver >= 0x24 && hwver_id != 9) {
+	if(cfg.ver >= 0x24 && hwver_id != 9 && hwver_id != 12) {
 		is += '<hr><button type="button" title="Get time clock delta" onclick="sendCustomSetting(&quot;24&quot;);">Get delta time</button>';
 		is += ' Adjust time clock delta: <input size="5" title="-32767..32767, in 1/16 us for 1 sec, default 0" id="cfg_time_step" maxlength="6" value="0">';
 		is += ' <button type="button" onclick="sendDeltaTime();">Set delta time</button>';
@@ -2882,7 +2882,7 @@ function CustomConfig() {
 	if(cfg.ver >= 0x37) {
 		is += '<b>Management GPIO_RS (Reed Switch):</b><br><br>';
 		is += 'RS mode: <select id="rds_type"><option value="0" selected>None</option><option value="1">Switch</option><option value="2">Counter</option>';
-		if(cfg.ver >= 0x42 && hwver_id != 9)
+		if(cfg.ver >= 0x42 && hwver_id != 9 && hwver_id != 12)
 			is += '<option value="3" selected>Connect</option>';
 		if(cfg.ver >= 0x39)	is += '</select>, Invert RS event: <input type="checkbox" id="rds_invert">';
 		is += '<br>RS report interval: <input size="8" title="0 - Off, 1..65535 sec, default 3600 sec" id="rds_rpint" maxlength="6" value="3600"> sec';
@@ -3071,7 +3071,7 @@ function hex(number, len) {
 }
 function SendCustomConfig() {
   if(hwver_id < 15 || (hwver_id >= 30 && hwver_id <= 33)) {
-	if(hwver_id != 9) {
+	if(hwver_id != 9 && hwver_id != 12) {
 		cfg.flg = ($("cfg_flg_adv_type").value & 3)+
 		(($("cfg_flg_comfort").checked) ? 4 : 0) +
 		(($("cfg_flg_blinking").checked) ? 8 : 0) +


### PR DESCRIPTION
Fixes issues during configuration, example:

```
TelinkMiFlasher.html:3077  Uncaught TypeError: Cannot read properties of null (reading 'checked')
    at SendCustomConfig (TelinkMiFlasher.html:3077:26)
    at HTMLButtonElement.onclick (TelinkMiFlasher.html:1:1)
```